### PR TITLE
Add expiry to the authentication mandate

### DIFF
--- a/interdevice.tex
+++ b/interdevice.tex
@@ -235,9 +235,10 @@ sends $c$ and the login URL $u$ to the device that scanned the barcode.
 just scanned to log in to their account at URL $u$. If yes, they select the username $r$ of the
 desired account (which may be autofilled from their database of services).
 \item If the user approves, the device goes through the usual mRSA signing flow to calculate a
-signature $s$, and sends the mandate $s \concat c \concat u \concat r \concat n \concat e$ to the
-device requesting authentication, using the secure channel. That device sends the mandate to the
-service to log in.
+signature $s$, and sends the mandate
+$s \concat c \concat u \concat r \concat \mathit{ex} \concat n \concat e$
+to the device requesting authentication, using the secure channel. That device sends the mandate to
+the service to log in.
 \end{enumerate}
 
 It is important that the user checks whether the authentication request is for the URL they were

--- a/protocol.tex
+++ b/protocol.tex
@@ -132,9 +132,9 @@ automatically behind the scenes.
 The mediator need only be partially trusted. It cannot authenticate as the user without the
 cooperation of one of the user's physical devices. The user only needs to trust the mediator to not
 collude with attackers who steal devices, and to correctly delete key fragments when the user
-requires key revocation. The user's privacy is protected by hashing the message $c \concat u \concat r$
-before sending it to the mediator, so it does not learn which services the user is logging in to,
-or which usernames they are using.
+requires key revocation. The user's privacy is protected by hashing the message
+$c \concat u \concat r \concat \mathit{ex}$ before sending it to the mediator, so it does not learn
+which services the user is logging in to, or which usernames they are using.
 
 From the point of view of a service that accepts Octokey login, the mediator does not even exist: a
 service simply verifies the RSA signature on a mandate, and does not care how that signature was
@@ -196,10 +196,10 @@ $\mathit{req} \concat \mathit{cb}^\prime$ for the user's public key $(n, e)$. Th
 $d_a^\prime = d_a$ (i.e. the user's password was correct), and if $\mathit{cb}^\prime = \mathit{cb}$
 (preventing MITM and replay attacks).
 \item If the signature is valid, the mediator computes
-$\mathit{resp} = H(c \concat u \concat r)^{d_b}$ as before, and returns it to the client. If the
-signature is not valid, the mediator returns ``bad signature''. A password-guessing attacker learns
-that the password guess $\mathit{pass}^\prime$ was incorrect, but otherwise nothing is revealed that
-would help them guess the password.
+$\mathit{resp} = H(c \concat u \concat r \concat \mathit{ex})^{d_b}$ as before, and returns it to
+the client. If the signature is not valid, the mediator returns ``bad signature''. A
+password-guessing attacker learns that the password guess $\mathit{pass}^\prime$ was incorrect, but
+otherwise nothing is revealed that would help them guess the password.
 \end{enumerate}
 
 Note that although the mediator computes an RSA signature using the user's private key, the value

--- a/protocol.tex
+++ b/protocol.tex
@@ -33,42 +33,43 @@ that a single password (like in a password manager) is an acceptable user experi
 Each user has a RSA keypair $(n, d, e)$ where $n$ is the modulus, $d$ is the private exponent and
 $e$ is the public exponent. A key also has an expiry date $\mathit{ex}$, which is chosen when the
 key is generated, and which is signed with the private key using a PKCS\#1 signature. The expiry is
-used to rotate the user's keypair periodically (see section~\ref{sec:rotation}).
+used to rotate the user's keypair periodically (see section~\ref{sec:rotation}). The service may
+have multiple public keys on record for a user, and should allow any one of those keys to authenticate
+as the user.
 
-When signing up to a service, the user submits their public key $n \concat e \concat \mathit{ex}$ to
-the service. The symbol $\concat$ denotes encoding and concatenating the values into a byte string.
-The service verifies the signature on $\mathit{ex}$ and stores the public key as part of the user
-record. The service may have multiple public keys on record for a user, and should allow any one of
-those keys to authenticate as the user.
-
-To log in, the user's client first requests a challenge $c$ from the service via a HTTP
+To log in or sign up, the user's client first requests a challenge $c$ from the service via a HTTP
 endpoint.\footnote{The format and contents of the challenge are unspecified -- the client treats it
 as an opaque byte string. However, we suggest that a service constructs a challenge from a
 timestamp $t$, a nonce $x$ and a secret key $K$ that is known only to the service:
 $c = t \concat x \concat \mathrm{HMAC}(K, t \concat x)$. The HMAC can be used to check that the
 challenge was issued by this service, $t$ can be used to verify freshness, and $x$ prevents reuse of
-a challenge.} It then calculates $m = H(c \concat u \concat r)$ where $u$ is the URL of the service endpoint and
-$r$ is the user's registered username. $H$ is shorthand for the \textsc{EMSA-PSS-Encode} operation
+a challenge.} It then calculates $m = H(c \concat u \concat r \concat \mathit{ex})$ where $u$ is the
+URL of the service endpoint $r$ is the user's registered username, and $\mathit{ex}$ is the expiry
+of their key. $H$ is shorthand for the \textsc{EMSA-PSS-Encode} operation
 (hashing and padding) as defined in PKCS\#1.~\cite{PKCS1} The RSA signature can then be calculated
 as $s = m^d \mod n$.
 
 The client then constructs the \emph{mandate}, which is an encoding of the RSA-signed message and
-the user's public key: $$\mathit{mandate} = s \concat c \concat u \concat r \concat n \concat e.$$
+the user's public key: $$\mathit{mandate} = s \concat c \concat u \concat r \concat \mathit{ex} \concat n \concat e.$$
 The mandate is sent to the server as part of a HTTP request over TLS, and is handled at the
 application layer. The server can verify the mandate by checking that all of the following are true:
 \begin{itemize}
-\item $s$ is a valid PKCS\#1 signature of the message $c \concat u \concat r$, checked against the
-public key $(n, e)$.
+\item $s$ is a valid PKCS\#1 signature of the message $c \concat u \concat r \concat \mathit{ex}$,
+checked against the public key $(n, e)$.
 \item $c$ is a valid challenge issued by this service, has not been used for login before, and is
 not older than some maximum age. This prevents replay attacks.
 \item $u$ is a valid URL for this service. A login request for an unknown URL must be rejected.
 This prevents phishing-like attacks, whereby an attacker creates an imitation website under a
 similar-looking URL and tricks the user into logging in.
 \item $r$ is a registered username for this service, and $(n, e, \mathit{ex})$ is a public key for
-that user, and $\mathit{ex}$ is not expired.
+that user.
+\item $\mathit{ex}$ is in the future.
 \end{itemize}
-If the mandate is successfully verified, the user is logged in by the server in the usual manner,
-for example by setting an appropriate session cookie.
+
+If a login mandate is successfully verified, the user is logged in by the server in the usual manner,
+for example by setting an appropriate session cookie. If a signup mandate is succesfully verified then
+the sign up flow continues as usual, with the server asking for the user's name, and verifying their
+email address as required.
 
 \subsection{Protection against key theft}\label{sec:revocation}
 
@@ -87,10 +88,10 @@ If two devices $a$ and $b$ each have a key fragment $d_a$ and $d_b$ respectively
 fragments sum to the private exponent $d$, then we call those devices \emph{paired}. In order to
 generate a valid signature, any two paired devices need to collaborate. If device $a$ wants to
 generate a mandate, it can send a signing request $\mathit{req}$ to device $b$:
-$$\mathit{req} = H(c \concat u \concat r) \concat n \concat e$$
+$$\mathit{req} = H(c \concat u \concat r \concat \mathit{ex}) \concat n \concat e$$
 where the public key $(n, e)$ indicates which key should be used, in case device $b$ stores multiple
 keys. Device $b$ then uses its key fragment $d_b$ to calculate a response:
-$$\mathit{resp} = H(c \concat u \concat r)^{d_b} = m^{d_b}$$
+$$\mathit{resp} = H(c \concat u \concat r \concat \mathit{ex})^{d_b} = m^{d_b}$$
 and returns $\mathit{resp}$ to $a$. Now, $a$ can calculate $s = m^{d_a} m^{d_b}$ by using its own
 key fragment $d_a$ and $\mathit{resp}$, construct a mandate with a valid signature, and thus log in.
 
@@ -167,7 +168,7 @@ We modify the mediator's request processing as follows:
 \item In addition to the signing request $\mathit{req}$, the client is required to submit a
 signature $s_\mathit{req}$:
 \begin{align*}
-    \mathit{req} &= H(c \concat u \concat r) \concat n \concat e \\
+    \mathit{req} &= H(c \concat u \concat r \concat \mathit{ex}) \concat n \concat e \\
     s_\mathit{req} &= H(\mathit{req} \concat \mathit{cb})^{d_a^\prime}
 \end{align*}
 where $\mathit{cb}$ is the \texttt{tls-unique} channel binding~\cite{ChannelBinding}

--- a/protocol.tex
+++ b/protocol.tex
@@ -101,9 +101,10 @@ generate a mandate, it can send a signing request $\mathit{req}$ to device $b$:
 $$\mathit{req} = H(c \concat u \concat r \concat \mathit{ex}) \concat n \concat e$$
 where the public key $(n, e)$ indicates which key should be used, in case device $b$ stores multiple
 keys. Device $b$ then uses its key fragment $d_b$ to calculate a response:
-$$\mathit{resp} = H(c \concat u \concat r \concat \mathit{ex})^{d_b} = m^{d_b}$$
-and returns $\mathit{resp}$ to $a$. Now, $a$ can calculate $s = m^{d_a} m^{d_b}$ by using its own
-key fragment $d_a$ and $\mathit{resp}$, construct a mandate with a valid signature, and thus log in.
+$$\mathit{resp} = H(c \concat u \concat r \concat \mathit{ex})^{d_b} = m^{d_b} \mod n$$
+and returns $\mathit{resp}$ to $a$. Now, $a$ can calculate
+$$s = H(c \concat u \concat r \concat \mathit{ex})^{d_a} \cdot \mathit{resp} = m^{d_a} m^{d_b} \mod n,$$
+construct a mandate with a valid signature, and thus log in.
 
 If a device is lost, stolen or compromised, this scheme allows the user to revoke that device's
 login capability: every device that is paired with the lost device must be instructed to delete the
@@ -179,7 +180,7 @@ We modify the mediator's request processing as follows:
 signature $s_\mathit{req}$:
 \begin{align*}
     \mathit{req} &= H(c \concat u \concat r \concat \mathit{ex}) \concat n \concat e \\
-    s_\mathit{req} &= H(\mathit{req} \concat \mathit{cb})^{d_a^\prime}
+    s_\mathit{req} &= H(\mathit{req} \concat \mathit{cb})^{d_a^\prime} \mod n
 \end{align*}
 where $\mathit{cb}$ is the \texttt{tls-unique} channel binding~\cite{ChannelBinding}
 of the TLS connection between the client and the mediator. Channel binding is further discussed in
@@ -190,16 +191,16 @@ section~\ref{sec:channels}), it can retrieve the key fragment for the authentica
 \item Using the channel binding $\mathit{cb}^\prime$ of the TLS connection's server side, the
 mediator computes
 $$s_\mathit{req} H(\mathit{req} \concat \mathit{cb}^\prime)^{d_b} =
-  H(\mathit{req} \concat \mathit{cb})^{d_a^\prime} H(\mathit{req} \concat \mathit{cb}^\prime)^{d_b}$$
+  H(\mathit{req} \concat \mathit{cb})^{d_a^\prime} H(\mathit{req} \concat \mathit{cb}^\prime)^{d_b} \mod n$$
 and checks whether the result is a valid PKCS\#1 signature of
 $\mathit{req} \concat \mathit{cb}^\prime$ for the user's public key $(n, e)$. This check succeeds if
 $d_a^\prime = d_a$ (i.e. the user's password was correct), and if $\mathit{cb}^\prime = \mathit{cb}$
 (preventing MITM and replay attacks).
 \item If the signature is valid, the mediator computes
-$\mathit{resp} = H(c \concat u \concat r \concat \mathit{ex})^{d_b}$ as before, and returns it to
-the client. If the signature is not valid, the mediator returns ``bad signature''. A
-password-guessing attacker learns that the password guess $\mathit{pass}^\prime$ was incorrect, but
-otherwise nothing is revealed that would help them guess the password.
+$$\mathit{resp} = H(c \concat u \concat r \concat \mathit{ex})^{d_b} \mod n$$
+as before, and returns it to the client. If the signature is not valid, the mediator returns ``bad
+signature''. A password-guessing attacker learns that the password guess $\mathit{pass}^\prime$ was
+incorrect, but otherwise nothing is revealed that would help them guess the password.
 \end{enumerate}
 
 Note that although the mediator computes an RSA signature using the user's private key, the value
@@ -207,10 +208,10 @@ being signed ($\mathit{req} \concat \mathit{cb}$) cannot be used to construct a 
 mediator cannot log in to services on the user's behalf.
 
 This protection against password guessing only works if the attacker does not have any knowledge of
-previous requests to the mediator. If the attacker knows $x^{d_a}$ (a request) or $x^{d_b}$ (a
-response) for any $x$, they can brute-force the password without contacting the mediator, and thus
-circumvent the rate-limiting.  It is therefore important that communication with the mediator is
-protected from eavesdropping (using TLS) and is not logged on the device.
+previous requests to the mediator. If the attacker knows $x^{d_a} \mod n$ (a request) or
+$x^{d_b} \mod n$ (a response) for any $x$, they can brute-force the password without contacting the
+mediator, and thus circumvent the rate-limiting.  It is therefore important that communication with
+the mediator is protected from eavesdropping (using TLS) and is not logged on the device.
 
 \subsection{Channel binding and preventing MITM}\label{sec:channelbinding}
 

--- a/protocol.tex
+++ b/protocol.tex
@@ -56,11 +56,10 @@ have multiple public keys on record for a user, and should allow any one of thos
 as the user.
 
 To log in or sign up, the user's client first requests a challenge $c$ from the service via a HTTP
-endpoint. It then calculates $m = H(c \concat u \concat r \concat \mathit{ex})$ where $u$ is the
-URL of the service endpoint $r$ is the user's registered username, and $\mathit{ex}$ is the expiry
-of their key. $H$ is shorthand for the \textsc{EMSA-PSS-Encode} operation
-(hashing and padding) as defined in PKCS\#1.~\cite{PKCS1} The RSA signature can then be calculated
-as $s = m^d \mod n$.
+endpoint. It then calculates $m = H(c \concat u \concat r \concat \mathit{ex})$ where $u$ is the URL
+of the service endpoint, $r$ is the user's registered username, and $\mathit{ex}$ is the expiry date
+of the key. $H$ is shorthand for the \textsc{EMSA-PSS-Encode} operation (hashing and padding) as
+defined in PKCS\#1.~\cite{PKCS1} The RSA signature can then be calculated as $s = m^d \mod n$.
 
 The client then constructs the \emph{mandate}, which is an encoding of the RSA-signed message and
 the user's public key: $$\mathit{mandate} = s \concat c \concat u \concat r \concat \mathit{ex} \concat n \concat e.$$
@@ -70,18 +69,18 @@ application layer. The server can verify the mandate by checking that all of the
 \item $s$ is a valid PKCS\#1 signature of the message $c \concat u \concat r \concat \mathit{ex}$,
 checked against the public key $(n, e)$.
 \item $c$ is a valid challenge, as defined in section~\ref{sec:challenges}.
-\item $u$ is a valid URL for this service. A login request for an unknown URL must be rejected.
-This prevents phishing-like attacks, whereby an attacker creates an imitation website under a
+\item $u$ is a valid URL for this service. A mandate for an unknown URL must be rejected. This
+prevents phishing-like attacks, whereby an attacker creates an imitation website under a
 similar-looking URL and tricks the user into logging in.
-\item $r$ is a registered username for this service, and $(n, e, \mathit{ex})$ is a public key for
-that user.
+\item For a signup request, the username $r$ is not yet taken. For a login request, $r$ is a
+registered username for this service, and $(n, e, \mathit{ex})$ is a public key for that user.
 \item $\mathit{ex}$ is in the future.
 \end{itemize}
 
-If a login mandate is successfully verified, the user is logged in by the server in the usual manner,
-for example by setting an appropriate session cookie. If a signup mandate is succesfully verified then
-the sign up flow continues as usual, with the server asking for the user's name, and verifying their
-email address as required.
+If a login mandate is successfully verified, the user is logged in by the server in the usual
+manner, for example by setting an appropriate session cookie. If a signup mandate is successfully
+verified, the signup flow continues as usual, e.g. asking for the user's name and verifying their
+email address.
 
 \subsection{Protection against key theft}\label{sec:revocation}
 

--- a/protocol.tex
+++ b/protocol.tex
@@ -50,10 +50,9 @@ brute-force attacks.
 
 Each user has a RSA keypair $(n, d, e)$ where $n$ is the modulus, $d$ is the private exponent and
 $e$ is the public exponent. A key also has an expiry date $\mathit{ex}$, which is chosen when the
-key is generated, and which is signed with the private key using a PKCS\#1 signature. The expiry is
-used to rotate the user's keypair periodically (see section~\ref{sec:rotation}). The service may
-have multiple public keys on record for a user, and should allow any one of those keys to authenticate
-as the user.
+key is generated, and which is used to rotate the user's keypair periodically (see
+section~\ref{sec:rotation}). The service may have multiple public keys on record for a user, and
+should allow any one of those keys to authenticate as the user.
 
 To log in or sign up, the user's client first requests a challenge $c$ from the service via a HTTP
 endpoint. It then calculates $m = H(c \concat u \concat r \concat \mathit{ex})$ where $u$ is the URL


### PR DESCRIPTION
This is required to protect against malicious signups, though it's
a little odd to also require it for login each time.

It might be more explicit to have a different message for each phase
of the protocol, but that comes with a significant trade-off of more
code complexity.
