### PR TITLE
Define password encryption

### DIFF
--- a/protocol.tex
+++ b/protocol.tex
@@ -224,25 +224,18 @@ function such as Scrypt~\cite{Percival09}. The parameters of the key derivation 
 parameter, pseudorandom function used, etc.) are stored in cleartext. We then generate a key stream
 using a symmetric block cipher such as AES-128 in CTR mode.~\cite{Lipmaa00}
 
-Say the key fragment we want to encrypt is $d_a$, and let $k$ be the minimum number of bits required
-to encode $d_a$ (i.e. $2^{k-1} \le d_a < 2^k$). We can now encrypt this value by taking the first
-$k$ bits of the AES-CTR key stream and XORing them with the $d_a$ bit string:
+Say the key fragment we want to encrypt is $d_a$, to encode $d_a$ we represent it as an $k$-bit
+number, where $k$ is the RSA key-length, using leading zeroes where necessary.  We can now encrypt this
+value by taking the first $k$ bits of the AES-CTR key stream and XORing them with the $d_a$ bit string:
 $$\mathit{efrag} = \mathit{ctr} \concat
-    (\mathrm{AESCTR}(\mathit{ctr}, \mathrm{scrypt}(\mathit{pass}))_{\{0 \dots k-1\}} \oplus d_a)$$
+    (\mathrm{AESCTR}(\mathit{ctr}, \mathrm{scrypt}(\mathit{pass}))_{\{0 \dots k\}} \oplus d_a)$$
 where $\mathit{ctr}$ is a 128-bit random nonce that is incremented by AESCTR for each subsequent
 block of key stream. The encrypted value is a pseudorandom number uniformly distributed between 0
 and $2^k$.
 
-However, this construction leaks some information: since the length of the encrypted bit string is
-$k$, an attacker can determine that $d_a$ must be between $2^{k-1}$ and $2^k$, and since the most
-significant bit of $d_a$ must be 1, a password-guessing attacker can reject half of the incorrect
-password guesses (those with a 0 bit) without contacting the mediator.
-
-To strengthen this, we can make the bit string $k^\prime = k + \alpha$ bits long, where $\alpha$ is
-chosen randomly such that $$p(\alpha = i) = 2^{-i-1} \quad (i \ge 0).$$ When $d_a$ is encoded into
-$k^\prime$ bits, the topmost $\alpha$ bits are zero. Thus, an attacker cannot rule out password
-guesses from examining the top bits of a decryption attempt, and the scheme only leaks the
-information that $d_a < 2^{k^\prime}$.
+Any attempt to decrypt this will result in a pseudo-random number between 0 and $2^k$. This is
+indistinguishable from a private key fragment, which is a random number between 0 and $d$, providing
+that the magnitude of $d$ is unknown.
 
 \subsection{Channel binding and preventing MITM}\label{sec:channelbinding}
 

--- a/protocol.tex
+++ b/protocol.tex
@@ -224,18 +224,27 @@ function such as Scrypt~\cite{Percival09}. The parameters of the key derivation 
 parameter, pseudorandom function used, etc.) are stored in cleartext. We then generate a key stream
 using a symmetric block cipher such as AES-128 in CTR mode.~\cite{Lipmaa00}
 
-Say the key fragment we want to encrypt is $d_a$, to encode $d_a$ we represent it as an $k$-bit
-number, where $k$ is the RSA key-length, using leading zeroes where necessary.  We can now encrypt this
-value by taking the first $k$ bits of the AES-CTR key stream and XORing them with the $d_a$ bit string:
+Let $k$ be the minimum number of bits required to encode the RSA modulus $n$ (i.e. the RSA key
+length). To encrypt the key fragment $d_a$, we first encode it as a $k$-bit string, using zeros for
+the most significant bits if necessary. We then take the first $k$ bits of the AES-CTR key stream
+and XOR them with the $d_a$ bit string:
 $$\mathit{efrag} = \mathit{ctr} \concat
-    (\mathrm{AESCTR}(\mathit{ctr}, \mathrm{scrypt}(\mathit{pass}))_{\{0 \dots k\}} \oplus d_a)$$
+    (\mathrm{AESCTR}(\mathit{ctr}, \mathrm{scrypt}(\mathit{pass}))_{\{0 \dots k-1\}} \oplus d_a)$$
 where $\mathit{ctr}$ is a 128-bit random nonce that is incremented by AESCTR for each subsequent
-block of key stream. The encrypted value is a pseudorandom number uniformly distributed between 0
-and $2^k$.
+block of key stream.
 
-Any attempt to decrypt this will result in a pseudo-random number between 0 and $2^k$. This is
-indistinguishable from a private key fragment, which is a random number between 0 and $d$, providing
-that the magnitude of $d$ is unknown.
+Any attempt to decrypt the key fragment results in a uniformly distributed pseudo-random number
+between 0 and $2^k$, whereas the correct key fragment is uniformly distributed between 0 and $d$.
+Since $d < 2^k$, a password guess that results in a larger decrypted value is less likely to be
+correct than a password guess that results in a smaller decrypted value. A password-guessing
+attacker can use this knowledge to prioritize guesses, but they cannot entirely rule out guesses
+without contacting the mediator.
+
+To quantify the bias, we repeatedly generated 2048-bit RSA keys using OpenSSL. Approximately 90\% of
+private exponents were in the range $0.05 < 2^{-k} d < 0.8$, with a fairly uniform distribution
+within that range. When key fragments $d_a$ (chosen uniformly from $[0, d]$) were encoded in $k$
+bits, they had on average 2.8 high-order zero bits, and the top bit was zero in 94\% of key
+fragments.
 
 \subsection{Channel binding and preventing MITM}\label{sec:channelbinding}
 
@@ -275,5 +284,3 @@ and rejecting certificates that do not appear in the log. Certificate Transparen
 against attackers who have stolen a website's private key (or governments, which can obtain the
 private key with a court order), but it does prevent more casual kinds of MITM attacks, so it may be
 sufficient.
-
-\pagebreak

--- a/protocol.tex
+++ b/protocol.tex
@@ -153,9 +153,8 @@ for example an encryption key that is derived from biometric measurements.} Cons
 has stolen this encrypted fragment. In order to brute-force the password, the attacker needs a way
 of determining whether a password guess is correct. However, a key fragment is just a uniformly
 distributed random number; by itself, the correctly decrypted key fragment is indistinguishable from
-the garbage that results from trying to decrypt with the wrong password.\footnote{If the encryption
-uses a block cipher, the key fragment must be padded with random bits up to the block size. Padding
-with a predictable bit pattern would leak information on whether a password guess was correct.}
+the garbage that results from trying to decrypt with the wrong password (see
+section~\ref{sec:fragmentenc}).
 
 Assuming the attacker has no other key fragments, they can only determine whether the password guess
 was correct by communicating with the mediator and testing whether they are able to construct a
@@ -213,6 +212,38 @@ $x^{d_b} \mod n$ (a response) for any $x$, they can brute-force the password wit
 mediator, and thus circumvent the rate-limiting.  It is therefore important that communication with
 the mediator is protected from eavesdropping (using TLS) and is not logged on the device.
 
+\subsection{Key fragment encryption}\label{sec:fragmentenc}
+
+The method described in section~\ref{sec:ratelimit} for rate-limiting password guesses depends on a
+correctly decrypted key fragment being indistinguishable from an incorrect password guess without
+contacting the mediator. In this section we propose an encryption scheme which satisfies that
+requirement.
+
+We first derive an encryption key from the password using a slow, memory-hard key derivation
+function such as Scrypt~\cite{Percival09}. The parameters of the key derivation function (salt, cost
+parameter, pseudorandom function used, etc.) are stored in cleartext. We then generate a key stream
+using a symmetric block cipher such as AES-128 in CTR mode.~\cite{Lipmaa00}
+
+Say the key fragment we want to encrypt is $d_a$, and let $k$ be the minimum number of bits required
+to encode $d_a$ (i.e. $2^{k-1} \le d_a < 2^k$). We can now encrypt this value by taking the first
+$k$ bits of the AES-CTR key stream and XORing them with the $d_a$ bit string:
+$$\mathit{efrag} = \mathit{ctr} \concat
+    (\mathrm{AESCTR}(\mathit{ctr}, \mathrm{scrypt}(\mathit{pass}))_{\{0 \dots k-1\}} \oplus d_a)$$
+where $\mathit{ctr}$ is a 128-bit random nonce that is incremented by AESCTR for each subsequent
+block of key stream. The encrypted value is a pseudorandom number uniformly distributed between 0
+and $2^k$.
+
+However, this construction leaks some information: since the length of the encrypted bit string is
+$k$, an attacker can determine that $d_a$ must be between $2^{k-1}$ and $2^k$, and since the most
+significant bit of $d_a$ must be 1, a password-guessing attacker can reject half of the incorrect
+password guesses (those with a 0 bit) without contacting the mediator.
+
+To strengthen this, we can make the bit string $k^\prime = k + \alpha$ bits long, where $\alpha$ is
+chosen randomly such that $$p(\alpha = i) = 2^{-i-1} \quad (i \ge 0).$$ When $d_a$ is encoded into
+$k^\prime$ bits, the topmost $\alpha$ bits are zero. Thus, an attacker cannot rule out password
+guesses from examining the top bits of a decryption attempt, and the scheme only leaks the
+information that $d_a < 2^{k^\prime}$.
+
 \subsection{Channel binding and preventing MITM}\label{sec:channelbinding}
 
 TLS connections are susceptible to man-in-the-middle attacks -- using forged TLS certificates, due
@@ -251,3 +282,5 @@ and rejecting certificates that do not appear in the log. Certificate Transparen
 against attackers who have stolen a website's private key (or governments, which can obtain the
 private key with a court order), but it does prevent more casual kinds of MITM attacks, so it may be
 sufficient.
+
+\pagebreak

--- a/references.bib
+++ b/references.bib
@@ -299,6 +299,14 @@
     howpublished = "BSDCan '09, \url{http://www.tarsnap.com/scrypt.html}"
 }
 
+@misc { Lipmaa00,
+    author = {Lipmaa, Helger and Rogaway, Phillip and Wagner, David},
+    title = {Comments to {NIST} concerning {AES} Modes of Operations: {CTR}-Mode Encryption},
+    year = {2000},
+    month = sep,
+    howpublished = "\url{http://web.cs.ucdavis.edu/~rogaway/papers/ctr.pdf}"
+}
+
 @misc { Borchert11,
     author = {Borchert, Bernd and Reinhardt, Klaus},
     title = {{V}erfahren zum {B}ereitstellen eines sicheren und komfortablen {Z}ugangs zu {O}nline-{A}ccounts via {F}ern-{W}eiterleitung},


### PR DESCRIPTION
One thing we gloss over right now is the storage format for passwords. Given that we make a big deal about the mediator being able to slow down brute force attacks, we should probably write out a scheme that makes that work. (even if it's so that someone with more experience can tell us that our scheme is broken).

I think the following scheme would work:

stored_password = _n_ || _ctr_ || (AES_CTR(_ctr_, PBKDF2(_password_)){0,_n_} XOR (_padding_ || _d_a_))

Where:
- _n_ is the RSA modulus (probably 2048)
- _ctr_ is a uniformly random number chosen at encryption time
- AES_CTR(ctr, key){0, _n_} is the first _n_ bits of the pseudo-random bit-stream generated by AES_CTR, with the counter initially set to _ctr_ ([source](http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/ctr/ctr-spec.pdf))
- PBKDF2 is a slow KDF (dashlane seems to tune the cost so it takes about 1 second on my laptop)
- _password_ is the users password
- _padding_ is _n_ - len(_d_a_) 0-bits. (i.e. _padding_ || _d_a_ gives you the _n_-bit representation of _d_a_ with leading zeros)
- _d_a_ is the client's half of the RSA private exponent.

The idea being that no-matter what password you give it, the AES_CTR gives you _n_ random-looking bits; when you XOR that with (_padding_ || _d_a_) you get a 2048-bit number. And a key-fragment is also a 2048-bit number.

Obviously a key-fragment is uniformly distributed in the range 0-_d_, not 0-2^n; so this isn't quite perfect. As you don't know _d_, you can't rule out any valid number, but you might be able to prioritise certain guesses over others based on the fact that a key-fragment is unlikely to be extremely close to _2^n_. But I'm not sure you can get very far (as any random numbers you decrypt are also unlikely to be extremely close to _2^n_).
